### PR TITLE
fix: ensure notifications are processed only once SQSERVICES-1107

### DIFF
--- a/Sources/NotificationSession.swift
+++ b/Sources/NotificationSession.swift
@@ -214,8 +214,6 @@ public class NotificationSession {
         self.applicationStatusDirectory = applicationStatusDirectory
         self.operationLoop = operationLoop
         self.strategyFactory = strategyFactory
-        
-        RequestAvailableNotification.notifyNewRequestsAvailable(nil)
     }
     
     public convenience init(coreDataStack: CoreDataStack,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/SQSERVICES-1107" title="SQSERVICES-1107" target="_blank"><img alt="Epic" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10807?size=medium" />SQSERVICES-1107</a>  Notification Service Extension
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Processing notifications, i.e converting fetched update events to `ZMLocalNotification`s and then passing that to the notification session delegate (the `NotificationService` in the notification service extension) is occurring multiple times. The effect of this is that we ask the notification service to call the content handler of the extension (which instructs iOS to display a local user notification) more than once. This in turn causes undesired outcomes, such as erroneous notifications to be shown, because it seems that this content handler should only be used once. 

### Causes

When we fetch events from the notification stream, these events may occur in batches. For each batch, we were creating the local notifications and passing them to the notification service (aka `delegate`). 

### Solutions

After converting all the update events to local notifications, store them in a buffer. When we see that we have finished fetching all events, then process the buffered notifications. 

## Note

Also, this PR removes one call to post the "requests available" notification when the notification session is initialised. It's not clear why it was there, but it seems unnecessary because we post this notification when triggering a fetch of events. Posting multiple times may cause the notification stream to be fetched multiple times, which also may lead to processing events multiple times.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
