### PR TITLE
fix: notifications not arriving SQCORE-1318

### DIFF
--- a/Sources/Synchronization/Strategies/PushNotificationStrategy.swift
+++ b/Sources/Synchronization/Strategies/PushNotificationStrategy.swift
@@ -32,7 +32,6 @@ final class PushNotificationStrategy: AbstractRequestStrategy, ZMRequestGenerato
     
     var sync: NotificationStreamSync!
     private var pushNotificationStatus: PushNotificationStatus!
-    private var eventProcessor: UpdateEventProcessor!
     private var moc: NSManagedObjectContext!
 
     weak var delegate: PushNotificationStrategyDelegate?
@@ -60,7 +59,6 @@ final class PushNotificationStrategy: AbstractRequestStrategy, ZMRequestGenerato
             delegate: self
         )
 
-        self.eventProcessor = self
         self.pushNotificationStatus = pushNotificationStatus
         self.moc = managedObjectContext
         self.eventDecoder = EventDecoder(eventMOC: eventContext, syncMOC: managedObjectContext)
@@ -131,7 +129,7 @@ extension PushNotificationStrategy: NotificationStreamSyncDelegate {
             }
         }
 
-        eventProcessor.storeUpdateEvents(parsedEvents, ignoreBuffer: true)
+        storeUpdateEvents(parsedEvents, ignoreBuffer: true)
         pushNotificationStatus.didFetch(eventIds: eventIds, lastEventId: latestEventId, finished: !hasMoreToFetch)
 
         if !hasMoreToFetch {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/SQCORE-1318" title="SQCORE-1318" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />SQCORE-1318</a>  [iOS] Notifications are not arriving
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Since the NSE was released, notifications sometimes don't arrive or arrive late.

### Causes

After a while the NSE gets in a state where it no longer operates correctly and fails to process notifications. The result of this is that no notifications are shown to the user. Late notifications are likely the user notifications scheduled from the main app when it periodically fetches and processes events. After some time, it seems that the NSE recovers and can process notifications again, but eventually it will get stuck again.

There are possible several causes to this, but they likely all related to the stability of the NSE. One such issue that I've found is a retain cycle which causes a memory leak for a several instances in the NSE. As iOS creates new instances of the NSE, these old and leaked instances will still exist in memory, and eventually our memory footprint will exceed the memory budget for the extension. At this point the NSE will probably be terminated.

Further evidence supporting this idea is that once the NSE is in this state, restarting the device will resolve the issue, as we likely enter a clean slate when restarting.

### Solutions

This PR removes a single retain cycle, which together this one other retain cycle in another framework (see https://github.com/wireapp/wire-ios-request-strategy/pull/533), accounts for all the memory leaks in the NSE.

### Testing

#### Test Coverage

- There are no unit tests for this, but I think we should consider finding some automated tools (linter?) to check that delegates are always `weak`.
- I did manual testing however and found the issue resolved: over a period of 3 days, I received hundreds of messages and there was a notification for every single message.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
